### PR TITLE
Look for libxml2 via pkg-config first.

### DIFF
--- a/recipe/0001-Look-for-libxml2-via-pkg-config-first.patch
+++ b/recipe/0001-Look-for-libxml2-via-pkg-config-first.patch
@@ -1,0 +1,76 @@
+From 69d526f2f57e3245fc2bb3601dde0df68fe723eb Mon Sep 17 00:00:00 2001
+From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+Date: Mon, 13 Feb 2017 02:34:01 -0500
+Subject: [PATCH] Look for libxml2 via pkg-config first.
+
+If no explicit path is specified, try pkg-config first, before
+xml2-config. The reason is that pkg-config knows the difference between
+static and shared dependencies and thus doesn't cause libxslt to be
+linked against a bunch of extra stuff.
+
+Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+---
+ configure.in | 26 +++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/configure.in b/configure.in
+index 019f022..1d14357 100644
+--- a/configure.in
++++ b/configure.in
+@@ -118,6 +118,7 @@ AC_PATH_PROG(MV, mv, /bin/mv)
+ AC_PATH_PROG(TAR, tar, /bin/tar)
+ AC_PATH_PROG(XMLLINT, xmllint, /usr/bin/xmllint)
+ AC_PATH_PROG(XSLTPROC, xsltproc, /usr/bin/xsltproc)
++PKG_PROG_PKG_CONFIG
+ 
+ AC_HEADER_STDC
+ 
+@@ -501,6 +502,26 @@ AC_ARG_WITH(libxml-src,
+ AC_SUBST(LIBXML_SRC)
+ 
+ dnl
++dnl Try pkg-config first if nothing is set
++dnl
++
++if test "x$LIBXML_CONFIG_PREFIX" == "x" -a "x$LIBXML_SRC" == "x"
++then
++	PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= $LIBXML_REQUIRED_VERSION], [
++		LIBXML_MANUAL_SEARCH=no
++		WITH_MODULES="`$PKG_CONFIG --variable=modules libxml-2.0`"
++	],
++	[
++		LIBXML_MANUAL_SEARCH=yes
++	])
++else
++	LIBXML_MANUAL_SEARCH=yes
++fi
++
++if test "x$LIBXML_MANUAL_SEARCH" != "xno"
++then
++
++dnl
+ dnl where is xml2-config
+ dnl
+ 
+@@ -578,6 +599,10 @@ else
+ 	AC_MSG_ERROR([Could not find libxml2 anywhere, check ftp://xmlsoft.org/.])
+ fi
+ 
++WITH_MODULES="`$XML_CONFIG --modules`"
++
++fi  # LIBXML_MANUAL_SEARCH
++
+ 
+ AC_SUBST(CFLAGS)
+ AC_SUBST(CPPFLAGS)
+@@ -602,7 +627,6 @@ fi
+ 
+ if test "$with_plugins" = "yes" ; then
+   AC_MSG_CHECKING([libxml2 module support])
+-  WITH_MODULES="`$XML_CONFIG --modules`"
+   if test "${WITH_MODULES}" = "1"; then
+     AC_MSG_RESULT(yes)
+   else
+-- 
+2.9.3
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,10 @@ requirements:
     - vc 10  # [win and py34]
     - vc 14  # [win and py>=35]
     - libxml2 2.9.*
+    # These three can be removed when the patch is dropped.
+    - automake  # [not win]
+    - libtool  # [not win]
+    - pkgconfig  # [not win]
   run:
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,12 @@ source:
   fn: libxslt-{{ version }}.tar.gz
   url: ftp://xmlsoft.org/libxml2/libxslt-{{ version }}.tar.gz
   sha256: b5976e3857837e7617b29f2249ebb5eeac34e249208d31f1fbf7a6ba7a4090ce
+  patches:
+    # https://bugzilla.gnome.org/show_bug.cgi?id=778549
+    - 0001-Look-for-libxml2-via-pkg-config-first.patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win and py>35]
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
This will eventually mean that libxslt doesn't get over-linked with libxml2's dependencies unnecessarily, and is the correct fix for #8.

**However**, since `libxml2` includes the useless libtool archive, it causes libtool to link against everything anyway. This will only really be properly fixed when we can do away with the libtool archive, or fix its useless dependencies.