### PR TITLE
Set and clear XML_CATALOG_FILES on activation and deactivation, respectively

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -35,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://gitlab.gnome.org/GNOME/libxslt
 
 Package license: MIT
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libxslt-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libxslt-pr-feedstock/blob/main/LICENSE.txt)
 
 Summary: The XSLT C library developed for the GNOME project
 
@@ -31,8 +31,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main">
           </a>
         </summary>
         <table>
@@ -40,43 +40,43 @@ Current build status
           <tbody><tr>
               <td>linux_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_ppc64le</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=585&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libxslt-pr-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,0 +1,2 @@
+set xml_catalog_files_libxslt="%XML_CATALOG_FILES%"
+set XML_CATALOG_FILES="%XML_CATALOG_FILES%:%CONDA_PREFIX%/etc/xml/catalog"

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,2 +1,2 @@
-set xml_catalog_files_libxslt="%XML_CATALOG_FILES%"
-set XML_CATALOG_FILES="%XML_CATALOG_FILES%:%CONDA_PREFIX%/etc/xml/catalog"
+set xml_catalog_files_libxslt=%XML_CATALOG_FILES%
+set XML_CATALOG_FILES=%CONDA_PREFIX%\etc\xml\catalog

--- a/recipe/activate.ps1
+++ b/recipe/activate.ps1
@@ -1,0 +1,2 @@
+$Env:xml_catalog_files_libxslt = "$Env:XML_CATALOG_FILES"
+$Env:XML_CATALOG_FILES = "$Env:CONDA_PREFIX\etc\xml\catalog"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export xml_catalog_files_libxslt="${XML_CATALOG_FILES}"
-export XML_CATALOG_FILES="${XML_CATALOG_FILES}:${CONDA_PREFIX}/etc/xml/catalog"
+export XML_CATALOG_FILES="${CONDA_PREFIX}/etc/xml/catalog"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export xml_catalog_files_libxslt="${XML_CATALOG_FILES}"
+export XML_CATALOG_FILES="${XML_CATALOG_FILES}:${CONDA_PREFIX}/etc/xml/catalog"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,3 +22,10 @@ if errorlevel 1 exit 1
 
 nmake /f Makefile.msvc install
 if errorlevel 1 exit 1
+
+setlocal EnableDelayedExpansion
+for %%F in (activate deactivate) DO (
+    if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
+    copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
+)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,5 +27,6 @@ setlocal EnableDelayedExpansion
 for %%F in (activate deactivate) DO (
     if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
     copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    copy %RECIPE_DIR%\%%F.ps1 %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.ps1
     copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
 )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,3 +23,8 @@ make install
 
 # We can remove this when we start using the new conda-build.
 find $PREFIX -name '*.la' -delete
+
+for f in "activate" "deactivate"; do
+    mkdir -p "${PREFIX}/etc/conda/${f}.d"
+    cp "${RECIPE_DIR}/${f}.sh" "${PREFIX}/etc/conda/${f}.d/${PKG_NAME}_${f}.sh"
+done

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,6 +1,6 @@
-if "%~xml_catalog_files_libxslt" == "" (
-    set xml_catalog_files_libxslt=
-) else (
+if defined xml_catalog_files_libxslt (
     set XML_CATALOG_FILES=%xml_catalog_files_libxslt%
+) else (
+    set XML_CATALOG_FILES=
 )
 set xml_catalog_files_libxslt=

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,6 @@
+if "%~xml_catalog_files_libxslt" == "" (
+    set xml_catalog_files_libxslt=
+) else (
+    set XML_CATALOG_FILES=%xml_catalog_files_libxslt%
+)
+set xml_catalog_files_libxslt=

--- a/recipe/deactivate.ps1
+++ b/recipe/deactivate.ps1
@@ -1,0 +1,6 @@
+if ($Env:xml_catalog_files_libxslt) {
+   $Env:XML_CATALOG_FILES = "$Env:xml_catalog_files_libxslt"
+} else {
+   $Env:XML_CATALOG_FILES = ''
+}
+$Env:xml_catalog_files_libxslt = ''

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if test -z "${xml_catalog_files_libxslt}"; then
-    unset XML_CATALOG_FILES
-else
+if test -n "${xml_catalog_files_libxslt}"; then
     export XML_CATALOG_FILES="${xml_catalog_files_libxslt}"
+else
+    unset XML_CATALOG_FILES
 fi
 unset xml_catalog_files_libxslt

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if test -z "${xml_catalog_files_libxslt}"; then
+    unset XML_CATALOG_FILES
+else
+    export XML_CATALOG_FILES="${xml_catalog_files_libxslt}"
+fi
+unset xml_catalog_files_libxslt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-win-profiler-config.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # forward compatible: https://abi-laboratory.pro/tracker/timeline/libxslt/
     - {{ pin_subpackage('libxslt') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is needed to avoid manually setting `XML_CATALOG_FILES` wherever `xsltproc` is run. Compile-time defaults cannot be used, because the value of `XML_CATALOG_FILES` will depend on the name of the environment where it is installed.

Caveats:
* The Windows variables are set as per [User guide](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables); it's not clear to me how this will work under _e.g._ PowerShell
* `xmlcatalog` seems to do The Right Thing regardless of the presence of `XML_CATALOG_FILES`
